### PR TITLE
Feature CU-868e5qyqe upload device logs

### DIFF
--- a/app/src/main/java/com/managexr/getserialsample/MXRAdminAppMessenger.java
+++ b/app/src/main/java/com/managexr/getserialsample/MXRAdminAppMessenger.java
@@ -45,7 +45,10 @@ public class MXRAdminAppMessenger {
         
         // System power management
         POWER_OFF(170),
-        REBOOT(180);
+        REBOOT(180),
+
+        // Other
+        UPLOAD_DEVICE_LOGS(23);
         
         private final int value;
 
@@ -288,6 +291,14 @@ public class MXRAdminAppMessenger {
      */
     public boolean rebootAsync() {
         return sendMessage(AdminAppMessageTypes.REBOOT.getValue());
+    }
+
+    /**
+     * Uploads the device logs to the ManageXR server.
+     * @return true if message was sent successfully
+     */
+    public boolean uploadDeviceLogsAsync() {
+        return sendMessage(AdminAppMessageTypes.UPLOAD_DEVICE_LOGS.getValue());
     }
 
     public boolean sendMessage(int what) {


### PR DESCRIPTION
### TL;DR

Added functionality to upload device logs to the ManageXR server.

### What changed?

- Added a new message type `UPLOAD_DEVICE_LOGS` with value `23` to the `AdminAppMessageTypes` enum
- Implemented a new method `uploadDeviceLogsAsync()` that sends the upload logs message to the ManageXR admin app

### Why make this change?

This change enables applications to programmatically trigger log uploads to the ManageXR server, which is useful for debugging and support purposes. It allows developers to collect device logs without requiring manual intervention from users.